### PR TITLE
Updated case for Dockerfile commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,41 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ubuntu:precise
+FROM ubuntu:precise
 
-maintainer Dockerfiles
+MAINTAINER Dockerfiles
 
-run echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
-run apt-get update
-run apt-get install -y build-essential git
-run apt-get install -y python python-dev python-setuptools
-run apt-get install -y nginx supervisor
-run easy_install pip
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get install -y build-essential git
+RUN apt-get install -y python python-dev python-setuptools
+RUN apt-get install -y nginx supervisor
+RUN easy_install pip
 
 # install uwsgi now because it takes a little while
-run pip install uwsgi
+RUN pip install uwsgi
 
 # install nginx
-run apt-get install -y python-software-properties
-run apt-get update
+RUN apt-get install -y python-software-properties
+RUN apt-get update
 RUN add-apt-repository -y ppa:nginx/stable
-run apt-get install -y sqlite3
+RUN apt-get install -y sqlite3
 
 # install our code
-add . /home/docker/code/
+ADD . /home/docker/code/
 
 # setup all the configfiles
-run echo "daemon off;" >> /etc/nginx/nginx.conf
-run rm /etc/nginx/sites-enabled/default
-run ln -s /home/docker/code/nginx-app.conf /etc/nginx/sites-enabled/
-run ln -s /home/docker/code/supervisor-app.conf /etc/supervisor/conf.d/
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+RUN rm /etc/nginx/sites-enabled/default
+RUN ln -s /home/docker/code/nginx-app.conf /etc/nginx/sites-enabled/
+RUN ln -s /home/docker/code/supervisor-app.conf /etc/supervisor/conf.d/
 
-# run pip install
-run pip install -r /home/docker/code/app/requirements.txt
+# RUN pip install
+RUN pip install -r /home/docker/code/app/requirements.txt
 
 # install django, normally you would remove this step because your project would already
 # be installed in the code/app/ directory
-run django-admin.py startproject website /home/docker/code/app/ 
+RUN django-admin.py startproject website /home/docker/code/app/ 
 
-expose 80
-cmd ["supervisord", "-n"]
+EXPOSE 80
+CMD ["supervisord", "-n"]


### PR DESCRIPTION
GitHub's syntax highlighter doesn't seem to like the lowercase Dockerfile commands, unless you're in the editor