### PR TITLE
python2 and python3 versions, use ubuntu 16.04

### DIFF
--- a/Dockerfile-py2
+++ b/Dockerfile-py2
@@ -20,17 +20,17 @@ MAINTAINER Dockerfiles
 
 RUN apt-get update && apt-get install -y \
 	git \
-	python3 \
-	python3-dev \
-	python3-setuptools \
-	python3-pip \
+	python \
+	python-dev \
+	python-setuptools \
+	python-pip \
 	nginx \
 	supervisor \
 	sqlite3 \
   && rm -rf /var/lib/apt/lists/*
 
 # install uwsgi now because it takes a little while
-RUN pip3 install uwsgi
+RUN pip install uwsgi
 
 # setup all the configfiles
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
@@ -38,10 +38,10 @@ COPY nginx-app.conf /etc/nginx/sites-available/default
 COPY supervisor-app.conf /etc/supervisor/conf.d/
 
 # COPY requirements.txt and RUN pip install BEFORE adding the rest of your code, this will cause Docker's caching mechanism
-# to prevent re-installing (all your) dependencies when you made a change a line or two in your app.
+# to prevent re-installinig (all your) dependencies when you made a change a line or two in your app.
 
 COPY app/requirements.txt /home/docker/code/app/
-RUN pip3 install -r /home/docker/code/app/requirements.txt
+RUN pip install -r /home/docker/code/app/requirements.txt
 
 # add (the rest of) our code
 COPY . /home/docker/code/

--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ as needed. Once you're really into making your project you'll notice you've
 touched most files here.
 
 ### Build and run
-* docker build -t webapp .
-* docker run -d webapp
+#### Build with python3
+* `docker build -t webapp .`
+* `docker run -d -p 80:80 webapp`
+* go to 127.0.0.1 to see if works
+#### Build with python2
+* `docker build -f Dockerfile-py2 -t webapp .`
+* `docker run -d -p 80:80 webapp`
+* go to 127.0.0.1 to see if works
 
 ### How to insert your application
 


### PR DESCRIPTION
Hi, I used https://github.com/dockerfiles/django-uwsgi-nginx/pull/14 as a reference to keep both versions.

Don't know if author planning to update it.

I updated both Dockerfiles, python2 docker file is different from 14.04 file in line `apt get install python-pip` , seems like that's correct way in 16.04 to install pip, instead of `easy_install pip`

I also updated Readme and mapped ports from container to host, seems like it would be easier to detect if container builded and started without problem on.